### PR TITLE
Use rpartition instead of rsplit

### DIFF
--- a/pytwitcher/base.py
+++ b/pytwitcher/base.py
@@ -57,7 +57,7 @@ class IrcObject:
         if name in self.registry.plugins:
             return
 
-        module_name, class_name = name.rsplit('.', 1)
+        module_name, _, class_name = name.rpartition('.')
 
         try:
             module = importlib.import_module(module_name)


### PR DESCRIPTION
```py
python -m timeit "a, b = 'path.Plugin'.rsplit('.', 1)"
1000000 loops, best of 3: 0.616 usec per loop

python -m timeit "a, _, b = 'path.Plugin'.rpartition('.')"
1000000 loops, best of 3: 0.346 usec per loop
```